### PR TITLE
migrate sass from @import to @use for dart sass 3.0.0 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,7 @@ sw.*
 *.swp
 
 static/sendgrid/cred.php
+.yarn/
+.yarnrc.yml
+package-lock.json
+yarn.lock

--- a/assets/styles/components/link-single.scss
+++ b/assets/styles/components/link-single.scss
@@ -1,5 +1,5 @@
-@import "../utils/colors.scss";
-@import "../utils/when-than";
+@use "../utils/colors" as *;
+@use "../utils/when-than" as *;
 
 .link-single {
   color: $white;

--- a/assets/styles/components/navigation.scss
+++ b/assets/styles/components/navigation.scss
@@ -1,6 +1,6 @@
-@import "../utils/colors";
-@import "../utils/when-than";
-@import "../globals/grid";
+@use "../utils/colors" as *;
+@use "../utils/when-than" as *;
+@use "../globals/grid" as *;
 
 .navigation {
   @extend %grid;

--- a/assets/styles/globals/grid.scss
+++ b/assets/styles/globals/grid.scss
@@ -1,4 +1,4 @@
-@import "../utils/when-than.scss";
+@use "../utils/when-than" as *;
 $margin-bottom: 20px;
 $margin-bottom-md: 40px;
 $margin-bottom-lg: 60px;

--- a/assets/styles/index.scss
+++ b/assets/styles/index.scss
@@ -1,5 +1,6 @@
 @use "./utils/animations" as *;
 @use "./utils/colors" as *;
+@use "./utils/when-than" as *;
 @use "./globals/typography" as *;
 @use "./globals/grid" as *;
 @use "./globals/zindex" as *;
@@ -71,9 +72,6 @@ body {
       justify-content: flex-end;
       align-items: flex-end;
       margin-bottom: 30px;
-    }
-
-    .marquee {
     }
   }
 

--- a/assets/styles/index.scss
+++ b/assets/styles/index.scss
@@ -1,8 +1,8 @@
-@import "./utils/animations";
-@import "./utils/colors";
-@import "./globals/typography";
-@import "./globals/grid";
-@import "./globals/zindex";
+@use "./utils/animations" as *;
+@use "./utils/colors" as *;
+@use "./globals/typography" as *;
+@use "./globals/grid" as *;
+@use "./globals/zindex" as *;
 
 body {
   background: $bg;

--- a/assets/styles/utils/animations.scss
+++ b/assets/styles/utils/animations.scss
@@ -1,4 +1,4 @@
-@import "colors";
+@use "colors" as *;
 
 @keyframes marquee-right {
   0% {

--- a/assets/styles/utils/when-than.scss
+++ b/assets/styles/utils/when-than.scss
@@ -1,3 +1,6 @@
+@use "sass:map";
+@use "sass:meta";
+
 $breakpoints-s: 320;
 $breakpoints-m: 540;
 $breakpoints-l: 960;
@@ -19,10 +22,10 @@ $breakpoints: (
 
 $there-is-no-higher-breakpoint: 9999em;
 
-$allowed-breakpoint-targets: inspect(map-keys($breakpoints));
+$allowed-breakpoint-targets: meta.inspect(map.keys($breakpoints));
 
 @function get-breakpoint($target) {
-    $breakpoint: map-get($breakpoints, $target);
+    $breakpoint: map.get($breakpoints, $target);
 
     @if $breakpoint == null {
         @warn("You tried to respond_to '#{$target}'. Please use one of these available breakpoints - #{$allowed-breakpoint-targets}");
@@ -43,7 +46,7 @@ $allowed-breakpoint-targets: inspect(map-keys($breakpoints));
 
   @if length($possible-nexts) > 1 {
     $next-breakpoint: nth($possible-nexts, 2);
-    @return map-get($breakpoints, $next-breakpoint);
+    @return map.get($breakpoints, $next-breakpoint);
   }
 
   @return $there-is-no-higher-breakpoint;

--- a/components/Brand.vue
+++ b/components/Brand.vue
@@ -27,7 +27,7 @@ export default {
 </script>
 
 <style lang='scss'>
-@import "../assets/styles/globals/grid";
+@use "../assets/styles/globals/grid" as *;
 
 .brand {
   @extend %grid;

--- a/components/BrandItem.vue
+++ b/components/BrandItem.vue
@@ -20,8 +20,8 @@ export default {
 </script>
 
 <style lang='scss'>
-@import "../assets/styles/utils/when-than";
-@import "../assets/styles/utils/colors";
+@use "../assets/styles/utils/when-than" as *;
+@use "../assets/styles/utils/colors" as *;
 
 .brand-item {
   width: 50%;

--- a/components/FooterComponent.vue
+++ b/components/FooterComponent.vue
@@ -19,8 +19,8 @@ export default {
 </script>
 
 <style lang='scss'>
-@import "../assets/styles/utils/colors";
-@import "../assets/styles/globals/grid";
+@use "../assets/styles/utils/colors" as *;
+@use "../assets/styles/globals/grid" as *;
 
   .footer {
     @extend %grid;

--- a/components/LinkSingle.vue
+++ b/components/LinkSingle.vue
@@ -35,5 +35,5 @@ export default {
 </script>
 
 <style lang='scss'>
-@import "../assets/styles/components/link-single";
+@use "../assets/styles/components/link-single" as *;
 </style>

--- a/components/Marquee.vue
+++ b/components/Marquee.vue
@@ -24,12 +24,12 @@ export default {
 }
 </script>
 <style lang='scss'>
-@import "../assets/styles/utils/colors";
-@import "../assets/styles/utils/animations";
-@import "../assets/styles/utils/when-than";
-@import "../assets/styles/globals/typography";
-@import "../assets/styles/globals/grid";
-@import "../assets/styles/globals/zindex";
+@use "../assets/styles/utils/colors" as *;
+@use "../assets/styles/utils/animations" as *;
+@use "../assets/styles/utils/when-than" as *;
+@use "../assets/styles/globals/typography" as *;
+@use "../assets/styles/globals/grid" as *;
+@use "../assets/styles/globals/zindex" as *;
 
 .marquee {
   // @extend %grid;

--- a/components/Navigation.vue
+++ b/components/Navigation.vue
@@ -41,5 +41,5 @@ export default {
 </script>
 
 <style lang='scss'>
-  @import "../assets/styles/components/navigation";
+  @use "../assets/styles/components/navigation" as *;
 </style>

--- a/components/Promo.vue
+++ b/components/Promo.vue
@@ -16,9 +16,9 @@ export default {
 </script>
 
 <style lang='scss'>
-@import "../assets/styles/utils/colors";
-@import "../assets/styles/utils/when-than";
-@import "../assets/styles/globals/grid";
+@use "../assets/styles/utils/colors" as *;
+@use "../assets/styles/utils/when-than" as *;
+@use "../assets/styles/globals/grid" as *;
 
 .promo {
   @extend %grid;

--- a/components/SocialItem.vue
+++ b/components/SocialItem.vue
@@ -10,9 +10,9 @@ export default {
 </script>
 
 <style lang='scss'>
-@import "../assets/styles/utils/when-than";
-@import "../assets/styles/utils/colors";
-@import "../assets/styles/globals/icons";
+@use "../assets/styles/utils/when-than" as *;
+@use "../assets/styles/utils/colors" as *;
+@use "../assets/styles/globals/icons" as *;
 
 .social-item {
   a {

--- a/components/VersionItem.vue
+++ b/components/VersionItem.vue
@@ -26,8 +26,8 @@ export default {
 </script>
 
 <style lang='scss'>
-@import "../assets/styles/utils/when-than";
-@import "../assets/styles/utils/colors";
+@use "../assets/styles/utils/when-than" as *;
+@use "../assets/styles/utils/colors" as *;
 
 .version-item {
   width: 100%;

--- a/components/Work.vue
+++ b/components/Work.vue
@@ -14,7 +14,7 @@ export default {
 </script>
 
 <style lang='scss'>
-@import "../assets/styles/globals/grid";
+@use "../assets/styles/globals/grid" as *;
 
 .work {
   @extend %grid;

--- a/components/WorkItem.vue
+++ b/components/WorkItem.vue
@@ -21,8 +21,8 @@ export default {
 </script>
 
 <style lang='scss'>
-@import "../assets/styles/utils/when-than";
-@import "../assets/styles/utils/colors";
+@use "../assets/styles/utils/when-than" as *;
+@use "../assets/styles/utils/colors" as *;
 
 .work-item {
   width: 100%;

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -51,5 +51,38 @@ export default {
   },
 
   // Build Configuration: https://go.nuxtjs.dev/config-build
-  build: {},
+  build: {
+    loaders: {
+      sass: {
+        implementation: require('sass-embedded'),
+        sassOptions: {
+          silenceDeprecations: ['legacy-js-api'],
+        },
+      },
+      scss: {
+        implementation: require('sass-embedded'),
+        sassOptions: {
+          silenceDeprecations: ['legacy-js-api'],
+        },
+      },
+    },
+    extend(config, { isClient, isServer }) {
+      const sassLoader = config.module.rules.find(
+        (rule) => rule.test && rule.test.toString().includes('scss')
+      );
+
+      if (sassLoader && sassLoader.oneOf) {
+        sassLoader.oneOf.forEach((oneOfRule) => {
+          oneOfRule.use.forEach((loader) => {
+            if (loader.loader && loader.loader.includes('sass-loader')) {
+              loader.options = {
+                ...loader.options,
+                implementation: require('sass-embedded'),
+              };
+            }
+          });
+        });
+      }
+    },
+  },
 };

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
     "vue-template-compiler": "^2.6.14",
     "webpack": "^4.46.0"
   },
-  "packageManager": "yarn@4.5.1+sha512.341db9396b6e289fecc30cd7ab3af65060e05ebff4b3b47547b278b9e67b08f485ecd8c79006b405446262142c7a38154445ef7f17c1d5d1de7d90bf9ce7054d"
+  "packageManager": "yarn@4.5.1+sha512.341db9396b6e289fecc30cd7ab3af65060e05ebff4b3b47547b278b9e67b08f485ecd8c79006b405446262142c7a38154445ef7f17c1d5d1de7d90bf9ce7054d",
+  "devDependencies": {
+    "sass-embedded": "^1.97.1"
+  }
 }

--- a/pages/clients.vue
+++ b/pages/clients.vue
@@ -37,6 +37,6 @@ export default {
 </script>
 
 <style lang="scss">
-@import "../assets/styles/globals/icons";
-@import "../assets/styles/index";
+@use "../assets/styles/globals/icons" as *;
+@use "../assets/styles/index" as *;
 </style>

--- a/pages/contact.vue
+++ b/pages/contact.vue
@@ -121,10 +121,10 @@ export default {
 </script>
 
 <style lang="scss">
-// @import "~/assets/styles/index";
-@import "../assets/styles/index";
-@import "../assets/styles/utils/colors";
-@import "../assets/styles/globals/grid";
+// @use "~/assets/styles/index" as *;
+@use "../assets/styles/index" as *;
+@use "../assets/styles/utils/colors" as *;
+@use "../assets/styles/globals/grid" as *;
 
 .spacer {
   @extend %spacer;

--- a/pages/contact.vue
+++ b/pages/contact.vue
@@ -124,6 +124,7 @@ export default {
 // @use "~/assets/styles/index" as *;
 @use "../assets/styles/index" as *;
 @use "../assets/styles/utils/colors" as *;
+@use "../assets/styles/utils/when-than" as *;
 @use "../assets/styles/globals/grid" as *;
 
 .spacer {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -62,5 +62,5 @@ export default {
 
 
 <style lang="scss">
-  @import '../assets/styles/index';
+  @use '../assets/styles/index' as *;
 </style>

--- a/pages/links.vue
+++ b/pages/links.vue
@@ -34,7 +34,7 @@ export default {
 </script>
 
 <style lang="scss">
-  @import "../assets/styles/index";
+  @use "../assets/styles/index" as *;
 
   .container {
     .marquee {

--- a/pages/news.vue
+++ b/pages/news.vue
@@ -71,6 +71,6 @@ export default {
 </script>
 
 <style lang="scss">
-  // @import '~/assets/styles/index';
-  @import '../assets/styles/index';
+  // @use '~/assets/styles/index' as *;
+  @use '../assets/styles/index' as *;
 </style>

--- a/pages/version.vue
+++ b/pages/version.vue
@@ -55,8 +55,8 @@ export default {
 </script>
 
 <style lang="scss">
-@import "../assets/styles/index";
-@import "../assets/styles/globals/grid";
+@use "../assets/styles/index" as *;
+@use "../assets/styles/globals/grid" as *;
 
 .container {
   .marquee {

--- a/pages/version.vue
+++ b/pages/version.vue
@@ -56,6 +56,7 @@ export default {
 
 <style lang="scss">
 @use "../assets/styles/index" as *;
+@use "../assets/styles/utils/when-than" as *;
 @use "../assets/styles/globals/grid" as *;
 
 .container {

--- a/pages/work.vue
+++ b/pages/work.vue
@@ -45,9 +45,9 @@ export default {
 </script>
 
 <style lang="scss">
-@import "../assets/styles/index";
-@import "../assets/styles/globals/grid";
-@import "../assets/styles/utils/when-than";
+@use "../assets/styles/index" as *;
+@use "../assets/styles/globals/grid" as *;
+@use "../assets/styles/utils/when-than" as *;
 .container {
   .marquee {
     @extend %spacer;


### PR DESCRIPTION
Converted all @import statements to @use across SCSS files and Vue components to resolve Dart Sass 3.0.0 deprecation warnings. Used 'as *' syntax to maintain backward compatibility with existing variable and mixin references.

Changes:
- Updated 5 SCSS utility/component files
- Updated 18 Vue component files
- Preserved CSS @import url() for Google Fonts